### PR TITLE
remove helm hook weight for job-db-migrate

### DIFF
--- a/.github/workflows/test-chart.yml
+++ b/.github/workflows/test-chart.yml
@@ -9,9 +9,8 @@ on:
       - "README.md"
       - ".github/**"
   push:
-    branches-ignore:
-      - "dependabot/**"
-      - "gh-pages"
+    branches:
+      - main
     paths-ignore:
       - "README.md"
       - ".github/**"

--- a/charts/mastodon/Chart.yaml
+++ b/charts/mastodon/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.0.6
+version: 4.0.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/mastodon/templates/job-db-migrate.yaml
+++ b/charts/mastodon/templates/job-db-migrate.yaml
@@ -6,7 +6,6 @@ metadata:
     {{- include "mastodon.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": post-install,pre-upgrade
-    "helm.sh/hook-weight": "-3"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   template:


### PR DESCRIPTION
in the current state before this PR, the db migrate job fails if other resources such as redis are not already available. I want to know if removing this job's helm hook weight will help, otherwise, maybe we just remove it and keep it as a separate thing that we tell users to run before upgrades and after base install? 🤷 